### PR TITLE
02 and 16 clean up user model

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,11 +1,10 @@
 class User < ApplicationRecord
-  belongs_to :garage 
-  #attr_accessor :username, :email, :garage
+  has_one :garage
+  after_create :add_garage
 
-  def setup(params = {})
-  	self.username = params.fetch(:username, "default_username")
-  	self.password = params.fetch(:password, "default_password")
-  	self.email = params.fetch(:email, "default@email.com")
-  	self.garage = Garage.new(user: self)
+  private
+
+  def add_garage
+    self.garage = Garage.new(user: self)
   end
 end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :user do
+    username { 'test' }
+    password { 'testpass' }
+    email { 'test@email.com' }
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,15 +1,14 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
+  subject(:user) { create(:user) }
 
-	user = User.new
-	user.setup(username: "test", password: "testpass", email: "test@email.com")
-	
-	it "expects new user to have username, password, email and garage" do
-		expect(user.username).to eq("test")
-		expect(user.password).to eq("testpass")
-		expect(user.email).to eq("test@email.com")
-		expect(user.garage).to be_truthy()
-		expect(user.garage).to be_a(Garage)
-	end
+  it 'adds a garage upon creation' do
+    expect { subject }.to change { Garage.count }.by(1)
+  end
+
+  describe 'user has a garage' do
+    subject { user.garage }
+    it { should_not be_nil }
+  end
 end


### PR DESCRIPTION
Closes the following issues around the User model.
- #2 Remove setup method 
- #16 Utilize after_create hook in User model
- #18 Utilize factories and clean up user specs